### PR TITLE
Resolve DELETE warnings

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -171,6 +171,9 @@ class Mockingbird {
    * Clears all expectations in Mockingbird.
    */
   clean() {
+    if (this.expectations.length === 0) {
+      return Promise.resolve(null);
+    }
     this.expectations = [];
     return rp({
       method: 'delete',


### PR DESCRIPTION
I've just started using this package as per recommendation of @jasperkuperus.
I'm running `await mock.clean()` in the `afterEach` callback of Jest, which results in:

```
2018-03-19T13:03:09.930Z - warn: DELETE /tests/e2e 404 1ms {"error":"Test 'undefined' not found"}
```
(`LOG_LEVEL=info`)

The Mockingbird server returns a 404 when trying to clean without any expectations.
This client handles it correctly: https://github.com/nolemmings/mockingbird-client/blob/master/src/client.js#L179.
However this does result in warning logs in the test output.

A solution would be to skip the `DELETE /tests/e2e` call when there are no expectations, but I'm not sure if this has any side effects.